### PR TITLE
Updates tests for swift-3.0-PREVIEW-6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "Nimble",
     exclude: [
       "Sources/NimbleObjectiveC",
-      "Tests/Nimble/objc"
+      "Tests/NimbleTests/objc"
     ]
 )

--- a/Sources/Nimble/FailureMessage.swift
+++ b/Sources/Nimble/FailureMessage.swift
@@ -39,10 +39,10 @@ public class FailureMessage: NSObject {
 
     internal func stripNewlines(_ str: String) -> String {
         var lines: [String] = NSString(string: str).components(separatedBy: "\n") as [String]
-        #if _runtime(_ObjC) // Xcode 8 beta 5
+        #if _runtime(_ObjC) // Xcode 8 beta 6
             let whitespace = NSCharacterSet.whitespacesAndNewlines
         #else
-            // swift-3.0-PREVIEW-4 for Linux
+            // swift-3.0-PREVIEW-6 for Linux
             let whitespace = NSCharacterSet.whitespacesAndNewlines()
         #endif
         lines = lines.map { line in NSString(string: line).trimmingCharacters(in: whitespace) }

--- a/Sources/Nimble/LinuxSupport.swift
+++ b/Sources/Nimble/LinuxSupport.swift
@@ -12,7 +12,7 @@ import XCTest
         internal class var `default`: NotificationCenter {
             return defaultCenter()
         }
-        internal func addObserver(forName name: NSNotification.Name?, object obj: AnyObject?, queue: OperationQueue?, using block: (Notification) -> Swift.Void) -> NSObjectProtocol {
+        internal func addObserver(forName name: NSNotification.Name?, object obj: AnyObject?, queue: OperationQueue?, using block: @escaping (Notification) -> Swift.Void) -> NSObjectProtocol {
             return addObserverForName(name, object: obj, queue: queue, usingBlock: block)
         }
     }

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -1,20 +1,6 @@
 import Foundation
 
 public func allPass<T,U>
-    (_ passFunc: @escaping (T) -> Bool) -> NonNilMatcherFunc<U>
-    where U: Sequence, U.Iterator.Element == T
-{
-    return allPass { (v: T?) -> Bool in v.map(passFunc) ?? false }
-}
-
-public func allPass<T,U>
-    (_ passName: String, _ passFunc: @escaping (T) -> Bool) -> NonNilMatcherFunc<U>
-    where U: Sequence, U.Iterator.Element == T
-{
-    return allPass(passName) { (v: T?) -> Bool in v.map(passFunc) ?? false }
-}
-
-public func allPass<T,U>
     (_ passFunc: @escaping (T?) -> Bool) -> NonNilMatcherFunc<U>
     where U: Sequence, U.Iterator.Element == T
 {

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -1,6 +1,20 @@
 import Foundation
 
 public func allPass<T,U>
+    (_ passFunc: @escaping (T) -> Bool) -> NonNilMatcherFunc<U>
+    where U: Sequence, U.Iterator.Element == T
+{
+    return allPass { (v: T?) -> Bool in v.map(passFunc) ?? false }
+}
+
+public func allPass<T,U>
+    (_ passName: String, _ passFunc: @escaping (T) -> Bool) -> NonNilMatcherFunc<U>
+    where U: Sequence, U.Iterator.Element == T
+{
+    return allPass(passName) { (v: T?) -> Bool in v.map(passFunc) ?? false }
+}
+
+public func allPass<T,U>
     (_ passFunc: @escaping (T?) -> Bool) -> NonNilMatcherFunc<U>
     where U: Sequence, U.Iterator.Element == T
 {

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -92,10 +92,7 @@ public func beCloseTo(_ expectedValues: [Double], within delta: Double = Default
 
 // MARK: - Operators
 
-infix operator ≈ {
-    associativity none
-    precedence 130
-}
+infix operator ≈ : ComparisonPrecedence
 
 public func ≈(lhs: Expectation<[Double]>, rhs: [Double]) {
     lhs.to(beCloseTo(rhs))
@@ -115,7 +112,11 @@ public func ==(lhs: Expectation<NMBDoubleConvertible>, rhs: (expected: NMBDouble
 
 // make this higher precedence than exponents so the Doubles either end aren't pulled in
 // unexpectantly
-infix operator ± { precedence 170 }
+precedencegroup PlusMinusOperatorPrecedence {
+    higherThan: BitwiseShiftPrecedence
+}
+
+infix operator ± : PlusMinusOperatorPrecedence
 public func ±(lhs: NMBDoubleConvertible, rhs: Double) -> (expected: NMBDoubleConvertible, delta: Double) {
     return (expected: lhs, delta: rhs)
 }

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -5,10 +5,18 @@ import Foundation
 /// as the expected instance.
 public func beIdenticalTo(_ expected: Any?) -> NonNilMatcherFunc<Any> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
-        let actual = try actualExpression.evaluate() as AnyObject?
+        #if os(Linux)
+            let actual = try actualExpression.evaluate() as? AnyObject
+        #else
+            let actual = try actualExpression.evaluate() as AnyObject?
+        #endif
         failureMessage.actualValue = "\(identityAsString(actual))"
         failureMessage.postfixMessage = "be identical to \(identityAsString(expected))"
-        return actual === (expected as AnyObject?) && actual !== nil
+        #if os(Linux)
+            return actual === (expected as? AnyObject) && actual !== nil
+        #else
+            return actual === (expected as AnyObject?) && actual !== nil
+        #endif
     }
 }
 

--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -1,5 +1,77 @@
 import Foundation
 
+extension Int8: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).int8Value
+    }
+}
+
+extension UInt8: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).uint8Value
+    }
+}
+
+extension Int16: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).int16Value
+    }
+}
+
+extension UInt16: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).uint16Value
+    }
+}
+
+extension Int32: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).int32Value
+    }
+}
+
+extension UInt32: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).uint32Value
+    }
+}
+
+extension Int64: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).int64Value
+    }
+}
+
+extension UInt64: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).uint64Value
+    }
+}
+
+extension Float: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).floatValue
+    }
+}
+
+extension Double: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).doubleValue
+    }
+}
+
+extension Int: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).intValue
+    }
+}
+
+extension UInt: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = NSNumber(value: value).uintValue
+    }
+}
+
 internal func matcherWithFailureMessage<T>(_ matcher: NonNilMatcherFunc<T>, postprocessor: @escaping (FailureMessage) -> Void) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         defer { postprocessor(failureMessage) }

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -26,7 +26,12 @@ public protocol Matcher {
 //extension NSHashTable : NMBContainer {} // Corelibs Foundation does not include this class yet
 #else
 public protocol NMBContainer {
-    func contains(_ anObject: Any) -> Bool
+    func contains(_ anObject: AnyObject) -> Bool
+}
+extension NMBContainer {
+    func contains(_ anObject: Any) -> Bool {
+        return contains(anObject as! AnyObject)
+    }
 }
 #endif
 
@@ -59,7 +64,12 @@ extension NSDictionary : NMBCollection {}
 }
 #else
 public protocol NMBOrderedCollection : NMBCollection {
-    func index(of anObject: Any) -> Int
+    func index(of anObject: AnyObject) -> Int
+}
+extension NMBOrderedCollection {
+    func index(of anObject: Any) -> Int {
+        return index(of: anObject as! AnyObject)
+    }
 }
 #endif
 

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -10,11 +10,7 @@ internal func identityAsString(_ value: Any?) -> String {
 }
 
 internal func classAsString(_ cls: AnyClass) -> String {
-#if _runtime(_ObjC)
     return NSStringFromClass(cls)
-#else
-    return String(cls)
-#endif
 }
 
 internal func arrayAsString<T>(_ items: [T], joiner: String = ", ") -> String {

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -2,11 +2,19 @@ import Foundation
 
 
 internal func identityAsString(_ value: Any?) -> String {
+#if os(Linux)
+    if let value = value as? AnyObject {
+        return NSString(format: "<%p>", unsafeBitCast(value, to: Int.self)).description
+    } else {
+        return "nil"
+    }
+#else
     if let value = value as AnyObject? {
         return NSString(format: "<%p>", unsafeBitCast(value, to: Int.self)).description
     } else {
         return "nil"
     }
+#endif
 }
 
 internal func classAsString(_ cls: AnyClass) -> String {

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -2,7 +2,7 @@ import Foundation
 
 
 internal func identityAsString(_ value: Any?) -> String {
-    if let value = value {
+    if let value = value as AnyObject? {
         return NSString(format: "<%p>", unsafeBitCast(value, to: Int.self)).description
     } else {
         return "nil"

--- a/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
+++ b/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
@@ -24,7 +24,7 @@ public protocol XCTestCaseProvider: XCTestCaseProviderStatic, XCTestCaseNameProv
 
 extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
     var allTestNames: [String] {
-        return self.dynamicType.allTests.map({ name, test in
+        return type(of: self).allTests.map({ name, test in
             return name
         })
     }

--- a/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
+++ b/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
@@ -33,7 +33,7 @@ extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
 #if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
 
 extension XCTestCase {
-    override public func tearDown() {
+    override open func tearDown() {
         if let provider = self as? XCTestCaseNameProvider {
             provider.assertContainsTest(invocation!.selector.description)
         }
@@ -43,7 +43,7 @@ extension XCTestCase {
 }
 
 extension XCTestCaseNameProvider {
-    private func assertContainsTest(_ name: String) {
+    fileprivate func assertContainsTest(_ name: String) {
         let contains = self.allTestNames.contains(name)
         XCTAssert(contains, "Test '\(name)' is missing from the allTests array")
     }

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -69,15 +69,15 @@ func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, li
 
 public class NimbleHelper : NSObject {
     public class func expectFailureMessage(_ message: NSString, block: @escaping () -> Void, file: FileString, line: UInt) {
-        failsWithErrorMessage(String(message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
+        failsWithErrorMessage(String(describing: message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
     public class func expectFailureMessages(_ messages: [NSString], block: @escaping () -> Void, file: FileString, line: UInt) {
-        failsWithErrorMessage(messages.map({ String($0) }), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
+        failsWithErrorMessage(messages.map({String(describing: $0)}), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
     public class func expectFailureMessageForNil(_ message: NSString, block: @escaping () -> Void, file: FileString, line: UInt) {
-        failsWithErrorMessageForNil(String(message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
+        failsWithErrorMessageForNil(String(describing: message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 }
 

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import Nimble
 import XCTest
 
-func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
+func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: @escaping () throws -> Void) {
     var filePath = file
     var lineNumber = line
 
@@ -44,7 +44,7 @@ func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line:
     }
 }
 
-func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: @escaping () -> Void) {
     return failsWithErrorMessage(
         [message],
         file: file,
@@ -54,12 +54,12 @@ func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UI
     )
 }
 
-func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: @escaping () -> Void) {
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 
 #if _runtime(_ObjC)
-    func deferToMainQueue(action: () -> Void) {
+    func deferToMainQueue(action: @escaping () -> Void) {
         DispatchQueue.main.async {
             Thread.sleep(forTimeInterval: 0.01)
             action()
@@ -68,15 +68,15 @@ func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, li
 #endif
 
 public class NimbleHelper : NSObject {
-    public class func expectFailureMessage(_ message: NSString, block: () -> Void, file: FileString, line: UInt) {
+    public class func expectFailureMessage(_ message: NSString, block: @escaping () -> Void, file: FileString, line: UInt) {
         failsWithErrorMessage(String(message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
-    public class func expectFailureMessages(_ messages: [NSString], block: () -> Void, file: FileString, line: UInt) {
+    public class func expectFailureMessages(_ messages: [NSString], block: @escaping () -> Void, file: FileString, line: UInt) {
         failsWithErrorMessage(messages.map({ String($0) }), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
-    public class func expectFailureMessageForNil(_ message: NSString, block: () -> Void, file: FileString, line: UInt) {
+    public class func expectFailureMessageForNil(_ message: NSString, block: @escaping () -> Void, file: FileString, line: UInt) {
         failsWithErrorMessageForNil(String(message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 }

--- a/Tests/NimbleTests/Matchers/AllPassTest.swift
+++ b/Tests/NimbleTests/Matchers/AllPassTest.swift
@@ -1,6 +1,47 @@
 import XCTest
 import Nimble
 
+/// Add operators to `Optional` for conforming `Comparable` that removed in Swift 3.0
+extension Optional where Wrapped: Comparable {
+    static func < (lhs: Optional, rhs: Optional) -> Bool {
+        switch (lhs, rhs) {
+        case let (l?, r?):
+            return l < r
+        case (nil, _?):
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func > (lhs: Optional, rhs: Optional) -> Bool {
+        switch (lhs, rhs) {
+        case let (l?, r?):
+            return l > r
+        default:
+            return rhs < lhs
+        }
+    }
+
+    static func <= (lhs: Optional, rhs: Optional) -> Bool {
+        switch (lhs, rhs) {
+        case let (l?, r?):
+            return l <= r
+        default:
+            return !(rhs < lhs)
+        }
+    }
+
+    static func >= (lhs: Optional, rhs: Optional) -> Bool {
+        switch (lhs, rhs) {
+        case let (l?, r?):
+            return l >= r
+        default:
+            return !(lhs < rhs)
+        }
+    }
+}
+
 final class AllPassTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (AllPassTest) -> () throws -> Void)] {
         return [

--- a/Tests/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Tests/NimbleTests/Matchers/BeEmptyTest.swift
@@ -19,7 +19,7 @@ final class BeEmptyTest: XCTestCase, XCTestCaseProvider {
 
 #if _runtime(_ObjC)
         expect(NSDictionary() as? [Int:Int]).to(beEmpty())
-        expect(NSDictionary(object: 1, forKey: 1) as? [Int:Int]).toNot(beEmpty())
+        expect(NSDictionary(object: 1, forKey: 1 as NSNumber) as? [Int:Int]).toNot(beEmpty())
 #endif
 
         expect(Dictionary<Int, Int>()).to(beEmpty())

--- a/Tests/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Tests/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -13,8 +13,10 @@ final class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
     func testGreaterThan() {
         expect(10).to(beGreaterThan(2))
         expect(1).toNot(beGreaterThan(2))
-#if _runtime(_ObjC)
+#if SUPPORT_IMPLICIT_BRIDGING_CONVERSION
         expect(NSNumber(value:3)).to(beGreaterThan(2))
+#else
+        expect(NSNumber(value:3)).to(beGreaterThan(2 as NSNumber))
 #endif
         expect(NSNumber(value:1)).toNot(beGreaterThan(NSNumber(value:2)))
 
@@ -35,8 +37,10 @@ final class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
     func testGreaterThanOperator() {
         expect(1) > 0
         expect(NSNumber(value:1)) > NSNumber(value:0)
-#if _runtime(_ObjC)
+#if SUPPORT_IMPLICIT_BRIDGING_CONVERSION
         expect(NSNumber(value:1)) > 0
+#else
+        expect(NSNumber(value:1)) > 0 as NSNumber
 #endif
         failsWithErrorMessage("expected to be greater than <2>, got <1>") {
             expect(1) > 2

--- a/Tests/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/Tests/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -27,7 +27,7 @@ final class BeIdenticalToObjectTest: XCTestCase, XCTestCaseProvider {
     }
     
     func testBeIdenticalToPositiveMessage() {
-        let message = String(NSString(format: "expected to be identical to <%p>, got <%p>",
+        let message = String(describing: NSString(format: "expected to be identical to <%p>, got <%p>",
             unsafeBitCast(testObjectB, to: Int.self), unsafeBitCast(testObjectA, to: Int.self)))
         failsWithErrorMessage(message) {
             expect(self.testObjectA).to(beIdenticalTo(self.testObjectB))
@@ -35,7 +35,7 @@ final class BeIdenticalToObjectTest: XCTestCase, XCTestCaseProvider {
     }
     
     func testBeIdenticalToNegativeMessage() {
-        let message = String(NSString(format: "expected to not be identical to <%p>, got <%p>",
+        let message = String(describing: NSString(format: "expected to not be identical to <%p>, got <%p>",
             unsafeBitCast(testObjectA, to: Int.self), unsafeBitCast(testObjectA, to: Int.self)))
         failsWithErrorMessage(message) {
             expect(self.testObjectA).toNot(beIdenticalTo(self.testObjectA))
@@ -43,13 +43,13 @@ final class BeIdenticalToObjectTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testFailsOnNils() {
-        let message1 = String(NSString(format: "expected to be identical to <%p>, got nil",
+        let message1 = String(describing: NSString(format: "expected to be identical to <%p>, got nil",
             unsafeBitCast(testObjectA, to: Int.self)))
         failsWithErrorMessageForNil(message1) {
             expect(nil as BeIdenticalToObjectTester?).to(beIdenticalTo(self.testObjectA))
         }
 
-        let message2 = String(NSString(format: "expected to not be identical to <%p>, got nil",
+        let message2 = String(describing: NSString(format: "expected to not be identical to <%p>, got nil",
             unsafeBitCast(testObjectA, to: Int.self)))
         failsWithErrorMessageForNil(message2) {
             expect(nil as BeIdenticalToObjectTester?).toNot(beIdenticalTo(self.testObjectA))

--- a/Tests/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Tests/NimbleTests/Matchers/BeLessThanTest.swift
@@ -13,12 +13,18 @@ final class BeLessThanTest: XCTestCase, XCTestCaseProvider {
     func testLessThan() {
         expect(2).to(beLessThan(10))
         expect(2).toNot(beLessThan(1))
-#if _runtime(_ObjC)
+#if SUPPORT_IMPLICIT_BRIDGING_CONVERSION
         expect(NSNumber(value:2)).to(beLessThan(10))
         expect(NSNumber(value:2)).toNot(beLessThan(1))
 
         expect(2).to(beLessThan(NSNumber(value:10)))
         expect(2).toNot(beLessThan(NSNumber(value:1)))
+#else
+        expect(NSNumber(value:2)).to(beLessThan(10 as NSNumber))
+        expect(NSNumber(value:2)).toNot(beLessThan(1 as NSNumber))
+
+        expect(2 as NSNumber).to(beLessThan(NSNumber(value:10)))
+        expect(2 as NSNumber).toNot(beLessThan(NSNumber(value:1)))
 #endif
 
         failsWithErrorMessage("expected to be less than <0>, got <2>") {
@@ -38,8 +44,10 @@ final class BeLessThanTest: XCTestCase, XCTestCaseProvider {
 
     func testLessThanOperator() {
         expect(0) < 1
-#if _runtime(_ObjC)
+#if SUPPORT_IMPLICIT_BRIDGING_CONVERSION
         expect(NSNumber(value:0)) < 1
+#else
+        expect(NSNumber(value:0)) < 1 as NSNumber
 #endif
         failsWithErrorMessage("expected to be less than <1>, got <2>") {
             expect(2) < 1

--- a/Tests/NimbleTests/Matchers/BeLogicalTest.swift
+++ b/Tests/NimbleTests/Matchers/BeLogicalTest.swift
@@ -44,11 +44,21 @@ final class BeTruthyTest : XCTestCase, XCTestCaseProvider {
 
     func testShouldMatchNonNilTypes() {
         expect(true as Bool?).to(beTruthy())
-        #if _runtime(_ObjC)
-            expect(1 as Int?).to(beTruthy())
-        #else
-            expect(1 as NSNumber?).to(beTruthy())
-        #endif
+
+        // Support types conforming to `ExpressibleByBooleanLiteral`
+        // Nimble extend following types as conforming to `ExpressibleByBooleanLiteral`
+        expect(1 as Int8?).to(beTruthy())
+        expect(1 as UInt8?).to(beTruthy())
+        expect(1 as Int16?).to(beTruthy())
+        expect(1 as UInt16?).to(beTruthy())
+        expect(1 as Int32?).to(beTruthy())
+        expect(1 as UInt32?).to(beTruthy())
+        expect(1 as Int64?).to(beTruthy())
+        expect(1 as UInt64?).to(beTruthy())
+        expect(1 as Float?).to(beTruthy())
+        expect(1 as Double?).to(beTruthy())
+        expect(1 as Int?).to(beTruthy())
+        expect(1 as UInt?).to(beTruthy())
     }
 
     func testShouldMatchTrue() {
@@ -61,12 +71,22 @@ final class BeTruthyTest : XCTestCase, XCTestCaseProvider {
 
     func testShouldNotMatchNilTypes() {
         expect(false as Bool?).toNot(beTruthy())
+
+        // Support types conforming to `ExpressibleByBooleanLiteral`
+        // Nimble extend following types as conforming to `ExpressibleByBooleanLiteral`
         expect(nil as Bool?).toNot(beTruthy())
-        #if _runtime(_ObjC)
-            expect(nil as Int?).toNot(beTruthy())
-        #else
-            expect(nil as NSNumber?).toNot(beTruthy())
-        #endif
+        expect(nil as Int8?).toNot(beTruthy())
+        expect(nil as UInt8?).toNot(beTruthy())
+        expect(nil as Int16?).toNot(beTruthy())
+        expect(nil as UInt16?).toNot(beTruthy())
+        expect(nil as Int32?).toNot(beTruthy())
+        expect(nil as UInt32?).toNot(beTruthy())
+        expect(nil as Int64?).toNot(beTruthy())
+        expect(nil as UInt64?).toNot(beTruthy())
+        expect(nil as Float?).toNot(beTruthy())
+        expect(nil as Double?).toNot(beTruthy())
+        expect(nil as Int?).toNot(beTruthy())
+        expect(nil as UInt?).toNot(beTruthy())
     }
 
     func testShouldNotMatchFalse() {
@@ -151,12 +171,22 @@ final class BeFalsyTest : XCTestCase, XCTestCaseProvider {
 
     func testShouldMatchNilTypes() {
         expect(false as Bool?).to(beFalsy())
+
+        // Support types conforming to `ExpressibleByBooleanLiteral`
+        // Nimble extend following types as conforming to `ExpressibleByBooleanLiteral`
         expect(nil as Bool?).to(beFalsy())
-        #if _runtime(_ObjC)
-            expect(nil as Int?).to(beFalsy())
-        #else
-            expect(nil as NSNumber?).to(beFalsy())
-        #endif
+        expect(nil as Int8?).to(beFalsy())
+        expect(nil as UInt8?).to(beFalsy())
+        expect(nil as Int16?).to(beFalsy())
+        expect(nil as UInt16?).to(beFalsy())
+        expect(nil as Int32?).to(beFalsy())
+        expect(nil as UInt32?).to(beFalsy())
+        expect(nil as Int64?).to(beFalsy())
+        expect(nil as UInt64?).to(beFalsy())
+        expect(nil as Float?).to(beFalsy())
+        expect(nil as Double?).to(beFalsy())
+        expect(nil as Int?).to(beFalsy())
+        expect(nil as UInt?).to(beFalsy())
     }
 
     func testShouldNotMatchTrue() {
@@ -169,11 +199,21 @@ final class BeFalsyTest : XCTestCase, XCTestCaseProvider {
 
     func testShouldNotMatchNonNilTypes() {
         expect(true as Bool?).toNot(beFalsy())
-        #if _runtime(_ObjC)
-            expect(1 as Int?).toNot(beFalsy())
-        #else
-            expect(1 as NSNumber?).toNot(beFalsy())
-        #endif
+
+        // Support types conforming to `ExpressibleByBooleanLiteral`
+        // Nimble extend following types as conforming to `ExpressibleByBooleanLiteral`
+        expect(1 as Int8?).toNot(beFalsy())
+        expect(1 as UInt8?).toNot(beFalsy())
+        expect(1 as Int16?).toNot(beFalsy())
+        expect(1 as UInt16?).toNot(beFalsy())
+        expect(1 as Int32?).toNot(beFalsy())
+        expect(1 as UInt32?).toNot(beFalsy())
+        expect(1 as Int64?).toNot(beFalsy())
+        expect(1 as UInt64?).toNot(beFalsy())
+        expect(1 as Float?).toNot(beFalsy())
+        expect(1 as Double?).toNot(beFalsy())
+        expect(1 as Int?).toNot(beFalsy())
+        expect(1 as UInt?).toNot(beFalsy())
     }
 
     func testShouldMatchFalse() {

--- a/Tests/NimbleTests/Matchers/EqualTest.swift
+++ b/Tests/NimbleTests/Matchers/EqualTest.swift
@@ -134,8 +134,8 @@ final class EqualTest: XCTestCase, XCTestCaseProvider {
         expect(actual).toNot(equal(unexpected))
 
 #if _runtime(_ObjC)
-        expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(["foo": "bar"]))
-        expect(NSDictionary(object: "bar", forKey: "foo") as? [String:String]).to(equal(expected))
+        expect(NSDictionary(object: "bar", forKey: "foo" as NSString)).to(equal(["foo": "bar"]))
+        expect(NSDictionary(object: "bar", forKey: "foo" as NSString) as? [String:String]).to(equal(expected))
 #endif
     }
 

--- a/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -14,7 +14,7 @@ final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
         ]
     }
 
-    var anException = NSException(name: "laugh" as NSExceptionName, reason: "Lulz", userInfo: ["key": "value"])
+    var anException = NSException(name: NSExceptionName(rawValue: "laugh"), reason: "Lulz", userInfo: ["key": "value"])
 
     func testPositiveMatches() {
         expect { self.anException.raise() }.to(raiseException())
@@ -25,7 +25,7 @@ final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
 
     func testPositiveMatchesWithClosures() {
         expect { self.anException.raise() }.to(raiseException { (exception: NSException) in
-            expect(exception.name).to(equal("laugh" as NSExceptionName))
+            expect(exception.name).to(equal(NSExceptionName(rawValue: "laugh")))
         })
         expect { self.anException.raise() }.to(raiseException(named: "laugh") { (exception: NSException) in
             expect(exception.name.rawValue).to(beginWith("lau"))
@@ -90,7 +90,7 @@ final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
     func testNegativeMatchesDoNotCallClosureWithoutException() {
         failsWithErrorMessage("expected to raise exception that satisfies block, got no exception") {
             expect { self.anException }.to(raiseException { (exception: NSException) in
-                expect(exception.name).to(equal("foo" as NSExceptionName))
+                expect(exception.name).to(equal(NSExceptionName(rawValue:"foo")))
             })
         }
         

--- a/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -49,40 +49,40 @@ final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testNegativeMatches() {
-        failsWithErrorMessage("expected to raise exception with name <foo>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to raise exception with name <foo>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.to(raiseException(named: "foo"))
         }
 
-        failsWithErrorMessage("expected to raise exception with name <laugh> with reason <bar>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to raise exception with name <laugh> with reason <bar>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "bar"))
         }
 
         failsWithErrorMessage(
-            "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{k = v;}>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+            "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{k = v;}>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["k": "v"]))
         }
 
         failsWithErrorMessage("expected to raise any exception, got no exception") {
             expect { self.anException }.to(raiseException())
         }
-        failsWithErrorMessage("expected to not raise any exception, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise any exception, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.toNot(raiseException())
         }
         failsWithErrorMessage("expected to raise exception with name <laugh> with reason <Lulz>, got no exception") {
             expect { self.anException }.to(raiseException(named: "laugh", reason: "Lulz"))
         }
 
-        failsWithErrorMessage("expected to raise exception with name <bar> with reason <Lulz>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to raise exception with name <bar> with reason <Lulz>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.to(raiseException(named: "bar", reason: "Lulz"))
         }
-        failsWithErrorMessage("expected to not raise exception with name <laugh>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise exception with name <laugh>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.toNot(raiseException(named: "laugh"))
         }
-        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.toNot(raiseException(named: "laugh", reason: "Lulz"))
         }
 
-        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.toNot(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]))
         }
     }
@@ -112,13 +112,13 @@ final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
                 })
         }
 
-        failsWithErrorMessage("expected to not raise any exception, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise any exception, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.toNot(raiseException())
         }
     }
 
     func testNegativeMatchesWithClosure() {
-        failsWithErrorMessage("expected to raise exception that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to raise exception that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }") {
             expect { self.anException.raise() }.to(raiseException { (exception: NSException) in
                 expect(exception.name.rawValue).to(equal("foo"))
             })
@@ -126,37 +126,37 @@ final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
 
         let innerFailureMessage = "expected to begin with <fo>, got <laugh>"
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "laugh") { (exception: NSException) in
                 expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "lol") { (exception: NSException) in
                 expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz") { (exception: NSException) in
                 expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <wrong> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <wrong> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "lol", reason: "wrong") { (exception: NSException) in
                 expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]) { (exception: NSException) in
                 expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <Lulz> with userInfo <{}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <Lulz> with userInfo <{}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[AnyHashable(\"key\"): \"value\"] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "lol", reason: "Lulz", userInfo: [:]) { (exception: NSException) in
                 expect(exception.name.rawValue).to(beginWith("fo"))
             })

--- a/Tests/NimbleTests/Matchers/SatisfyAnyOfTest.swift
+++ b/Tests/NimbleTests/Matchers/SatisfyAnyOfTest.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Nimble
+import Foundation
 
 final class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (SatisfyAnyOfTest) -> () throws -> Void)] {
@@ -11,8 +12,10 @@ final class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
 
     func testSatisfyAnyOf() {
         expect(2).to(satisfyAnyOf(equal(2), equal(3)))
-#if _runtime(_ObjC)
+#if SUPPORT_IMPLICIT_BRIDGING_CONVERSION
         expect(2).toNot(satisfyAnyOf(equal(3), equal("turtles")))
+#else
+        expect(2 as NSNumber).toNot(satisfyAnyOf(equal(3 as NSNumber), equal("turtles" as NSString)))
 #endif
         expect([1,2,3]).to(satisfyAnyOf(equal([1,2,3]), allPass({$0 < 4}), haveCount(3)))
         expect("turtle").toNot(satisfyAnyOf(contain("a"), endWith("magic")))
@@ -40,8 +43,10 @@ final class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
     
     func testOperatorOr() {
         expect(2).to(equal(2) || equal(3))
-#if _runtime(_ObjC)
+#if SUPPORT_IMPLICIT_BRIDGING_CONVERSION
         expect(2).toNot(equal(3) || equal("turtles"))
+#else
+        expect(2 as NSNumber).toNot(equal(3 as NSNumber) || equal("turtles" as NSString))
 #endif
         expect("turtle").toNot(contain("a") || endWith("magic"))
         expect(82.0).toNot(beLessThan(10.5) || beGreaterThan(100.75))

--- a/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
@@ -133,11 +133,7 @@ final class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testNegativeMatchesWithClosure() {
-#if SWIFT_PACKAGE
-        let moduleName = "NimbleTestSuite"
-#else
         let moduleName = "NimbleTests"
-#endif
         let innerFailureMessage = "expected to equal <foo>, got <\(moduleName).NimbleError>"
         let closure = { (error: Error) in
             print("** In closure! With domain \(error._domain)")

--- a/Tests/NimbleTests/objc/ObjCRaiseExceptionTest.m
+++ b/Tests/NimbleTests/objc/ObjCRaiseExceptionTest.m
@@ -80,7 +80,7 @@
                               userInfo(@{@"k": @"v"}));
     });
 
-    expectFailureMessage(@"expected to not raise any exception, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }", ^{
+    expectFailureMessage(@"expected to not raise any exception, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[AnyHashable(\"key\"): value] }", ^{
         expectAction(^{ [exception raise]; }).toNot(raiseException());
     });
 }
@@ -96,7 +96,7 @@
         }));
     });
 
-    NSString *outerFailureMessage = @"expected to raise exception that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
+    NSString *outerFailureMessage = @"expected to raise exception that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[AnyHashable(\"key\"): value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  satisfyingBlock(^(NSException *exception) {
@@ -104,7 +104,7 @@
         }));
     });
 
-    outerFailureMessage = @"expected to raise exception with name <foo> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <foo> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[AnyHashable(\"key\"): value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(@"foo").
@@ -113,7 +113,7 @@
         }));
     });
 
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <bar> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <bar> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[AnyHashable(\"key\"): value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).
@@ -123,7 +123,7 @@
         }));
     });
 
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[AnyHashable(\"key\"): value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).
@@ -142,7 +142,7 @@
     NSString *outerFailureMessage;
 
     NSString const *innerFailureMessage = @"expected to equal <foo>, got <NSInvalidArgumentException>";
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[AnyHashable(\"key\"): value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).
@@ -152,7 +152,7 @@
     });
 
 
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[AnyHashable(\"key\"): value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).
@@ -163,7 +163,7 @@
     });
 
 
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{key = value;}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{key = value;}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[AnyHashable(\"key\"): value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).


### PR DESCRIPTION
- Fix exclude in Package.swift
- Update for Linux
- Update tests
  - Apply `@escaping`
  - Change `dynamicType` to `type(of:)`
  - Fix access levels
  - Cast keys of NSDictionary to Foundation types explicitly
  - Change `NSExceptionName` casting to initializing
